### PR TITLE
fix: correct git config commands and project name variable

### DIFF
--- a/hooks/pre
+++ b/hooks/pre
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GIT_EMAIL=`git config user.email`
-GIT_AUTHOR=`git config user.name`
+GIT_EMAIL=`git config get user.email`
+GIT_AUTHOR=`git config get user.name`
 
 echo "{\"git_email\": \"${GIT_EMAIL}\", \"git_author\": \"${GIT_AUTHOR}\"}"

--- a/hooks/pre
+++ b/hooks/pre
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GIT_EMAIL=`git config get user.email`
-GIT_AUTHOR=`git config get user.name`
+GIT_EMAIL=`git config user.email`
+GIT_AUTHOR=`git config user.name`
 
 echo "{\"git_email\": \"${GIT_EMAIL}\", \"git_author\": \"${GIT_AUTHOR}\"}"

--- a/pyproject.toml.baker.j2
+++ b/pyproject.toml.baker.j2
@@ -1,5 +1,5 @@
 [project]
-name = "{{ project_name }}"
+name = "{{ project_slug }}"
 version = "0.1.0"
 description = "{{ project_description }}"
 readme = "README.md"


### PR DESCRIPTION
- Remove 'get' subcommand from git config calls in pre hook
- Change project name from 'project_name' to 'project_slug' in pyproject.toml template

The 'git config get' syntax was incorrect - git config directly accepts the configuration key without the 'get' subcommand.